### PR TITLE
添加了“带有字符串的临时二维码类型”

### DIFF
--- a/src/main/java/com/github/sd4324530/fastweixin/api/enums/QrcodeType.java
+++ b/src/main/java/com/github/sd4324530/fastweixin/api/enums/QrcodeType.java
@@ -13,6 +13,10 @@ public enum QrcodeType {
      */
     QR_SCENE,
 
+	 /**
+     * 带有字符串参数的临时二维码
+     */
+	QR_STR_SCENE,
     /**
      * 永久二维码
      */


### PR DESCRIPTION
目前微信公众号支持 带有字符串的临时二维码。字符串参数可以表达的场景更为丰富，并且，临时二维码没有数量限制。
 https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542